### PR TITLE
Upgrape in plotting mass plan script 

### DIFF
--- a/bamboo_/ZAMachineLearning/Plotting/PlotMassPlane.py
+++ b/bamboo_/ZAMachineLearning/Plotting/PlotMassPlane.py
@@ -366,8 +366,7 @@ if __name__ == "__main__":
         with open(os.path.join('data','points_0.500000_0.500000.json')) as f:
             d = json.load(f)
             masspoints = [(mH, mA,) for mA, mH in d]
-        #masspoints = [(200, 100)]#, ( 300, 50)]#, ( 300, 100), ( 300, 200),]
-        masspoints = [(500, 300)]
+        masspoints = [(200, 100), ( 300, 50), ( 300, 100), ( 300, 200)]
 
         pbar = enlighten.Counter(total=len(masspoints), desc='Progress', unit='mass points')
         if not args.jobs:


### PR DESCRIPTION
Command I used 
```
python PlotMassPlane.py    --ZA --model ../model/all_combined_dict_343.zip --inputs pdgid=11 era=2016 --projection  -j 4
``` 
- With `--inputs` you can change the era and pdgid (can be extended to other args ofc) on the command line, the pdf printed will have the info in its name, this way you can easily get the shapes per parameter
- Updated the projection part to take into account the averaging over the triangle binning 
- Added multiprocessing for the production of the graphs (with `-j <threads`) to speed up things (needed to change a few things in the code), although the plotting is still in serie.